### PR TITLE
Add Homebrew script to install/update common apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # FirstBoot
-Script to set core apps and settings for new deployment
+
+Script to set core apps and settings for new deployment.
+
+## Homebrew app updater
+
+Use `./homebrew-update.sh` to ensure that common applications are installed and up to date on a new macOS machine. The script will install Homebrew if it isn't present and then install or upgrade the apps listed in the `APPS` array inside the script.
+
+```bash
+./homebrew-update.sh
+```
+
+Customize the `APPS` variable in the script to match the tools you want on your system.

--- a/homebrew-update.sh
+++ b/homebrew-update.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# homebrew-update.sh
+# Script to install or update common applications using Homebrew.
+# This script checks whether Homebrew is installed, installs it if needed,
+# and then ensures that a predefined list of applications are installed
+# and up to date. Customize the APPS array to fit your needs.
+
+set -euo pipefail
+
+APPS=(git wget node python3 htop tmux)
+
+install_homebrew() {
+  echo "Homebrew not found. Installing..."
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+}
+
+ensure_app_installed() {
+  local app="$1"
+  if brew list "$app" >/dev/null 2>&1; then
+    echo "Upgrading $app..."
+    brew upgrade "$app" || true
+  else
+    echo "Installing $app..."
+    brew install "$app"
+  fi
+}
+
+main() {
+  if ! command -v brew >/dev/null 2>&1; then
+    install_homebrew
+  fi
+
+  echo "Updating Homebrew..."
+  brew update
+
+  for app in "${APPS[@]}"; do
+    ensure_app_installed "$app"
+  done
+
+  echo "Cleaning up..."
+  brew cleanup
+  echo "All apps are up to date!"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- add `homebrew-update.sh` to install or update a list of applications via Homebrew on macOS
- document script usage in README

## Testing
- `bash -n homebrew-update.sh`
- `shellcheck homebrew-update.sh` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_b_6895e7a830b4832a9e3d6c024bdd9849