### PR TITLE
Add Homebrew cask installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ Script to set core apps and settings for new deployment.
 
 ## Homebrew app updater
 
-Use `./homebrew-update.sh` to ensure that common applications are installed and up to date on a new macOS machine. The script will install Homebrew if it isn't present and then install or upgrade the apps listed in the `APPS` array inside the script.
+Use `./homebrew-update.sh` to ensure that common applications are installed and up to date on a new macOS machine. The script will install Homebrew if it isn't present and then install or upgrade the tools listed in the `APPS` array and the macOS applications listed in the `CASKS` array.
 
 ```bash
 ./homebrew-update.sh
 ```
 
-Customize the `APPS` variable in the script to match the tools you want on your system.
+Customize the `APPS` and `CASKS` variables in the script to match the tools and apps you want on your system.

--- a/homebrew-update.sh
+++ b/homebrew-update.sh
@@ -8,7 +8,11 @@
 
 set -euo pipefail
 
+# Command-line tools to install/upgrade
 APPS=(git wget node python3 htop tmux)
+
+# GUI applications distributed as casks
+CASKS=(1password cursor chatgpt)
 
 install_homebrew() {
   echo "Homebrew not found. Installing..."
@@ -26,6 +30,17 @@ ensure_app_installed() {
   fi
 }
 
+ensure_cask_installed() {
+  local app="$1"
+  if brew list --cask "$app" >/dev/null 2>&1; then
+    echo "Upgrading $app..."
+    brew upgrade --cask "$app" || true
+  else
+    echo "Installing $app..."
+    brew install --cask "$app"
+  fi
+}
+
 main() {
   if ! command -v brew >/dev/null 2>&1; then
     install_homebrew
@@ -36,6 +51,10 @@ main() {
 
   for app in "${APPS[@]}"; do
     ensure_app_installed "$app"
+  done
+
+  for cask in "${CASKS[@]}"; do
+    ensure_cask_installed "$cask"
   done
 
   echo "Cleaning up..."


### PR DESCRIPTION
## Summary
- add support for installing/upgrading GUI apps as Homebrew casks
- include 1Password, Cursor, and ChatGPT in default casks list
- document new `CASKS` array in README

## Testing
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*
- `shellcheck homebrew-update.sh` *(fails: command not found)*
- `bash -n homebrew-update.sh`


------
https://chatgpt.com/codex/tasks/task_b_6895e95b6de4832a9a4b54c4f83ae041